### PR TITLE
fix return from direnv--export

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -93,26 +93,27 @@ In these modes, direnv will use `default-directory' instead of
         ;; call-process can only output stderr to file
         (stderr-tempfile (make-temp-file "direnv-stderr")))
 
-    (with-current-buffer (get-buffer-create direnv--output-buffer-name)
-      (erase-buffer)
-      (let* ((default-directory directory)
-             (process-environment environment)
-             (exit-code (call-process "direnv" nil `(t ,stderr-tempfile) nil "export" "json")))
-        (unless (zerop exit-code)
-          ; write the stderr messages to the end of our output buffer
-          (insert-file-contents stderr-tempfile)
-          ; then fill a temp buffer with the message and display in status bar
-          (with-temp-buffer
-            (insert-file-contents stderr-tempfile)
-              (message "direnv exited %s:\n%s\nOpen hidden buffer \"%s\" for full output"
-                       exit-code (buffer-string) direnv--output-buffer-name)))
-        (unless (zerop (buffer-size))
-          (goto-char (point-max))
-          (re-search-backward "^{")
-          (let ((json-key-type 'string))
-            (json-read-object)))))
+    (unwind-protect
+        (with-current-buffer (get-buffer-create direnv--output-buffer-name)
+          (erase-buffer)
+          (let* ((default-directory directory)
+                 (process-environment environment)
+                 (exit-code (call-process "direnv" nil `(t ,stderr-tempfile) nil "export" "json")))
+            (unless (zerop exit-code)
+                                        ; write the stderr messages to the end of our output buffer
+              (insert-file-contents stderr-tempfile)
+                                        ; then fill a temp buffer with the message and display in status bar
+              (with-temp-buffer
+                (insert-file-contents stderr-tempfile)
+                (message "direnv exited %s:\n%s\nOpen hidden buffer \"%s\" for full output"
+                         exit-code (buffer-string) direnv--output-buffer-name)))
+            (unless (zerop (buffer-size))
+              (goto-char (point-max))
+              (re-search-backward "^{")
+              (let ((json-key-type 'string))
+                (json-read-object)))))
 
-    (delete-file stderr-tempfile)))
+      (delete-file stderr-tempfile))))
 
 (defun direnv--enable ()
   "Enable direnv mode."


### PR DESCRIPTION
After e1f45aa (#34) `direnv--export` returns `(delete-file stderr-tempfile)` (i.e. nil) instead of `(json-read-object)`, so changes aren't picked up.

This just wraps with `unwind-protect` so that correct value is returned and temp file is deleted even if something throws an error.

`prog1` would also work.