### PR TITLE
Readme and unhide and changelog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,9 @@ history
     `#34 <https://github.com/wbolster/emacs-direnv/pull/34>`_
   * make the ``*direnv*`` buffer easier to find by removing the
     leading space
-  * add ``eshell`` and ``direv`` to list of non-file-modes
+  * add ``eshell`` and ``dired`` to list of non-file-modes; see
+    `#36 <https://github.com/wbolster/emacs-direnv/pull/36>`_ and
+    `#33 <https://github.com/wbolster/emacs-direnv/issues/33>`_
 
 * 1.4.0 (2018-03-01)
 

--- a/README.rst
+++ b/README.rst
@@ -161,19 +161,12 @@ the output of the last ``direnv`` invocation,
 which will likely contain more information
 about the source of the problem.
 
-this buffer will be automatically shown
-when ``direnv`` exits with a non-zero status code,
+when an error happens, the direnv stderr will
+be automatically shown in the message area,
 but for non-fatal problems
 such as incorrect ``.envrc`` files
-you may have to open this buffer manually for inspection.
-
-if you use ``direnv-mode`` and an error occurs,
-emacs will automatically disable the hook
-that ``direnv-mode`` installed.
-after fixing the problem,
-call ``direnv-update-environment`` manually
-to ensure the problem is solved,
-then re-enable ``direnv-mode``.
+you may have to open this buffer manually for inspection
+of the full output of the last ``direnv`` call.
 
 
 contributing

--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,11 @@ history
 
   * handle indirect buffers correctly; see
     `#25 <https://github.com/wbolster/emacs-direnv/issues/25>`_
+  * display ``direnv`` errors in the message area; see
+    `#34 <https://github.com/wbolster/emacs-direnv/pull/34>`_
+  * make the ``*direnv*`` buffer easier to find by removing the
+    leading space
+  * add ``eshell`` and ``direv`` to list of non-file-modes
 
 * 1.4.0 (2018-03-01)
 

--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,7 @@ troubleshooting
 ===============
 
 if you experience problems,
-first check the hidden buffer named ``*direnv*``
-(with a leading space before the name).
+first check the buffer named ``*direnv*``.
 this buffer contains
 the output of the last ``direnv`` invocation,
 which will likely contain more information

--- a/direnv.el
+++ b/direnv.el
@@ -37,8 +37,8 @@
   "Detect the direnv executable."
   (executable-find "direnv"))
 
-(defvar direnv--output-buffer-name " *direnv*"
-  "Name of the hidden buffer used for direnv interaction.")
+(defvar direnv--output-buffer-name "*direnv*"
+  "Name of the buffer filled with the last direnv output.")
 
 (defvar direnv--installed (direnv--detect)
   "Whether direnv is installed.")


### PR DESCRIPTION
This is a followup to https://github.com/wbolster/emacs-direnv/pull/34, in which the README and changelog are updated, and the `*direnv*` buffer is made non-hidden.