### PR TITLE
Only parse the stdout from direnv export json

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -92,27 +92,26 @@ In these modes, direnv will use `default-directory' instead of
   (let ((environment process-environment)
         ;; call-process can only output stderr to file
         (stderr-tempfile (make-temp-file "direnv-stderr")))
-
     (unwind-protect
         (with-current-buffer (get-buffer-create direnv--output-buffer-name)
           (erase-buffer)
           (let* ((default-directory directory)
                  (process-environment environment)
                  (exit-code (call-process "direnv" nil `(t ,stderr-tempfile) nil "export" "json")))
-            (unless (zerop exit-code)
-                                        ; write the stderr messages to the end of our output buffer
-              (insert-file-contents stderr-tempfile)
-                                        ; then fill a temp buffer with the message and display in status bar
+            (prog1 (unless (zerop (buffer-size))
+                     (goto-char (point-max))
+                     (re-search-backward "^{")
+                     (let ((json-key-type 'string))
+                       (json-read-object)))
+              (unless (zerop (file-attribute-size (file-attributes stderr-tempfile)))
+                (unless (zerop (buffer-size)) (insert "\n"))
+                ;; write the stderr messages to the end of our output buffer
+                (insert-file-contents stderr-tempfile))
               (with-temp-buffer
                 (insert-file-contents stderr-tempfile)
-                (message "direnv exited %s:\n%s\nOpen hidden buffer \"%s\" for full output"
-                         exit-code (buffer-string) direnv--output-buffer-name)))
-            (unless (zerop (buffer-size))
-              (goto-char (point-max))
-              (re-search-backward "^{")
-              (let ((json-key-type 'string))
-                (json-read-object)))))
-
+                (unless (zerop exit-code)
+                  (message "direnv exited %s:\n%s\nOpen buffer \"%s\" for full output"
+                           exit-code (buffer-string) direnv--output-buffer-name))))))
       (delete-file stderr-tempfile))))
 
 (defun direnv--enable ()

--- a/direnv.el
+++ b/direnv.el
@@ -90,22 +90,23 @@ In these modes, direnv will use `default-directory' instead of
   (unless direnv--installed
     (user-error "Could not find the direnv executable. Is exec-path correct?"))
   (let ((environment process-environment)
-        ;; call-process can only output stderr to file
-        (stderr-tempfile (make-temp-file "direnv-stderr")))
+        (stderr-tempfile (make-temp-file "direnv-stderr"))) ;; call-process needs a file for stderr output
     (unwind-protect
         (with-current-buffer (get-buffer-create direnv--output-buffer-name)
           (erase-buffer)
           (let* ((default-directory directory)
                  (process-environment environment)
-                 (exit-code (call-process "direnv" nil `(t ,stderr-tempfile) nil "export" "json")))
-            (prog1 (unless (zerop (buffer-size))
-                     (goto-char (point-max))
-                     (re-search-backward "^{")
-                     (let ((json-key-type 'string))
-                       (json-read-object)))
+                 (exit-code (call-process "direnv" nil `(t ,stderr-tempfile) nil "export" "json"))
+                 (json-key-type 'string))
+            (prog1
+                (unless (zerop (buffer-size))
+                  (goto-char (point-max))
+                  (re-search-backward "^{")
+                  (json-read-object))
               (unless (zerop (file-attribute-size (file-attributes stderr-tempfile)))
-                (unless (zerop (buffer-size)) (insert "\n"))
-                ;; write the stderr messages to the end of our output buffer
+                (goto-char (point-max))
+                (unless (zerop (buffer-size))
+                  (insert "\n\n"))
                 (insert-file-contents stderr-tempfile))
               (with-temp-buffer
                 (unless (zerop exit-code)

--- a/direnv.el
+++ b/direnv.el
@@ -108,10 +108,10 @@ In these modes, direnv will use `default-directory' instead of
                 ;; write the stderr messages to the end of our output buffer
                 (insert-file-contents stderr-tempfile))
               (with-temp-buffer
-                (insert-file-contents stderr-tempfile)
                 (unless (zerop exit-code)
-                  (message "direnv exited %s:\n%s\nOpen buffer \"%s\" for full output"
-                           exit-code (buffer-string) direnv--output-buffer-name))))))
+                  (insert-file-contents stderr-tempfile)
+                  (warn "Error running direnv (exit code %d):\n%s\nOpen buffer ‘%s’ for full output."
+                        exit-code (buffer-string) direnv--output-buffer-name))))))
       (delete-file stderr-tempfile))))
 
 (defun direnv--enable ()


### PR DESCRIPTION
Then, put stderr into `*direnv*`.

Side effect: exit code now only affects the warning message.

Tested:

Happy path: I ran `(direnv--export "/Users/andstrib/somedir")` and it returns a list of environment key/value cons pairs. `*direnv*` contained the output and a line from stderr.

Unhappy path: Then I changed the function to run `direnv export this-does-not-work` and re-ran it. It didn't parse the error message, but did write to `*Messages*` and `*direnv*`.