### PR TITLE
Treat direnv-non-file-modes as possibly derived modes.

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -76,9 +76,9 @@ instead of
 (defun direnv--directory ()
   "Return the relevant directory for the current buffer, or nil."
   (let* ((buffer (or (buffer-base-buffer) (current-buffer)))
-	 (file-name (buffer-file-name buffer)))
+         (file-name (buffer-file-name buffer)))
     (cond (file-name (file-name-directory file-name))
-	  ((apply #'derived-mode-p direnv-non-file-modes) default-directory))))
+          ((apply #'derived-mode-p direnv-non-file-modes) default-directory))))
 
 (defun direnv--export (directory)
   "Call direnv for DIRECTORY and return the parsed result."

--- a/direnv.el
+++ b/direnv.el
@@ -66,17 +66,19 @@ usually results in coloured output."
 (defcustom direnv-non-file-modes '(eshell-mode dired-mode)
   "List of modes where direnv will update even if the buffer has no file.
 
-In these modes, direnv will use `default-directory' instead of
-`(file-name-directory (buffer-file-name (current-buffer)))'."
+In these modes, or modes derived from them, direnv will use
+  `default-directory'
+instead of
+  `(file-name-directory (buffer-file-name (current-buffer)))'."
   :group 'direnv
   :type '(repeat (symbol :tag "Major mode")))
 
 (defun direnv--directory ()
   "Return the relevant directory for the current buffer, or nil."
   (let* ((buffer (or (buffer-base-buffer) (current-buffer)))
-         (file-name (buffer-file-name buffer)))
+	 (file-name (buffer-file-name buffer)))
     (cond (file-name (file-name-directory file-name))
-          ((member major-mode direnv-non-file-modes) default-directory))))
+	  ((apply #'derived-mode-p direnv-non-file-modes) default-directory))))
 
 (defun direnv--export (directory)
   "Call direnv for DIRECTORY and return the parsed result."


### PR DESCRIPTION
Suppose we're in a Magit Status buffer, whose `major-mode` is `magit-status-mode`, which is derived from `magit-mode`.

With this change, if `direnv-non-file-modes` contains `magit-mode`, `direnv-mode`
will now treat it as a non-file mode.

Open question: do we add `magit-mode` to the default list?