### PR TITLE
direnv--directory: Predicate derived-mode test on base buffer mode

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -76,9 +76,12 @@ instead of
 (defun direnv--directory ()
   "Return the relevant directory for the current buffer, or nil."
   (let* ((buffer (or (buffer-base-buffer) (current-buffer)))
+         (mode (with-current-buffer buffer major-mode))
          (file-name (buffer-file-name buffer)))
-    (cond (file-name (file-name-directory file-name))
-          ((apply #'derived-mode-p direnv-non-file-modes) default-directory))))
+    (cond (file-name
+           (file-name-directory file-name))
+          ((apply #'provided-mode-derived-p mode direnv-non-file-modes)
+           default-directory))))
 
 (defun direnv--export (directory)
   "Call direnv for DIRECTORY and return the parsed result."


### PR DESCRIPTION
Eg: I have a magit status buffer, which I clone with
`clone-indirect-buffer-other-window`, then change its mode to
fundamental. The directory returned by `direnv--directory` should not
care about the major mode of my indirect buffer.

Tested by doing the above.