### PR TITLE
Prevent `eshell-path-env` getting out-of-sync with $PATH

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -227,7 +227,10 @@ When FORCE-SUMMARY is non-nil or when called interactively, show a summary messa
             (value (cdr pair)))
         (setenv name value)
         (when (string-equal name "PATH")
-          (setq exec-path (append (parse-colon-path value) (list exec-directory))))))))
+          (setq exec-path (append (parse-colon-path value) (list exec-directory)))
+          ;; Prevent `eshell-path-env` getting out-of-sync with $PATH:
+          (when (eq major-mode 'eshell-mode)
+            (setq eshell-path-env value)))))))
 
 ;;;###autoload
 (defun direnv-allow ()

--- a/direnv.el
+++ b/direnv.el
@@ -229,7 +229,7 @@ When FORCE-SUMMARY is non-nil or when called interactively, show a summary messa
         (when (string-equal name "PATH")
           (setq exec-path (append (parse-colon-path value) (list exec-directory)))
           ;; Prevent `eshell-path-env` getting out-of-sync with $PATH:
-          (when (eq major-mode 'eshell-mode)
+          (when (derived-mode-p 'eshell-mode)
             (setq eshell-path-env value)))))))
 
 ;;;###autoload


### PR DESCRIPTION
When changing `.envrc` in a running Eshell session, changes to `$PATH` don't have any effect:

```sh
Welcome to the Emacs shell

$ mkdir foo && cd foo
$ echo "#!/bin/sh" > bar.sh
$ echo "echo 'works!'" >> bar.sh
$ chmod +x bar.sh
$ ./bar.sh
works!

$ echo "PATH_add ." > .envrc
$ direnv allow
$ direnv-update-directory-environment
direnv: ~PATH (~/dev/emacs-direnv/foo)
$ echo $PATH
/home/dkellner/dev/emacs-direnv/foo:...

$ bar.sh
bar.sh: command not found
$ sh -c "bar.sh"
works!
```

After updating `eshell-path-env` to the current value of `$PATH`, the behaviour is as expected:

```sh
$ (setq eshell-path-env (getenv "PATH"))
/home/dkellner/dev/emacs-direnv/foo:...
$ bar.sh
works!
```