### PR TITLE
customize direnv executable args

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -39,6 +39,9 @@
 (defvar direnv--executable (direnv--detect)
   "Detected path of the direnv executable.")
 
+(defvar direnv--executable-args '("export" "json")
+  "Direnv executable args")
+
 (defvar direnv--active-directory nil
   "Name of the directory for which direnv has most recently ran.")
 
@@ -103,10 +106,9 @@ use `default-directory', since there is no file name (or directory)."
           (erase-buffer)
           (let* ((default-directory directory)
                  (process-environment environment)
-                 (exit-code (call-process
-                             direnv--executable nil
-                             `(t ,stderr-tempfile) nil
-                             "export" "json")))
+                 (exit-code (apply 'call-process
+                                   (append `(,direnv--executable nil (t ,stderr-tempfile) nil)
+                                           direnv--executable-args))))
             (prog1
                 (unless (zerop (buffer-size))
                   (goto-char (point-max))


### PR DESCRIPTION
Customizing direnv executable args allows running scripts instead of the raw
direnv command.

For example calling:
```lisp
  (let ((direnv--executable (executable-find "nix-shell"))
        (direnv--executable-args '("--run" "jq -n env"))
        (direnv-always-show-summary nil))
    (direnv-update-environment))
```
will allow extracting environment variables from nix-shell without actually
running direnv. This is useful when you want to apply environment variables
provided by nix shell to current emacs session.