### PR TITLE
Revert "require package in minor mode definition"

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -275,7 +275,6 @@ When FORCE-SUMMARY is non-nil or when called interactively, show a summary messa
 When this mode is active, the environment inside Emacs will be
 continuously updated to match the direnv environment for the currently
 visited (local) file."
-  :require 'direnv
   :global t
   (if direnv-mode
       (direnv--enable)


### PR DESCRIPTION
This reverts commit 255ea5680d19f942c6c9f2eae0cd9eb05d0e9c50.

Since package-lint 0.7, `:require` is only suggested when the
minor-mode is not autoloaded.  Since this minor-mode is autoloaded,
the customzation will correctly load direnv.el when it needs to.

This also fixes a buggy interaction with Spacemacs where, upon saving
the customization for `direnv-mode`, the REQUIRES field is populated
in the `custom-load-variables`.  This require fails in Spacemacs
because it occurs before `load-path` has been set up properly.