### PR TITLE
Minute Administrivia

### DIFF
--- a/direnv.el
+++ b/direnv.el
@@ -43,8 +43,14 @@
 
 ;;; Commentary:
 
-;; This package provides direnv integration for Emacs.
-;; See the README for more information.
+;; Direnv (https://direnv.net/) integration for Emacs.
+
+;; Enable the global `direnv-mode' minor mode to have inferior shells,
+;; linters, compilers, and test runners start with the intended
+;; environmental variables.
+
+;; Using the command `direnv-allow' you can mark a ".envrc" as safe
+;; (remember to always first check if it trustworthy)
 
 ;;; Code:
 

--- a/direnv.el
+++ b/direnv.el
@@ -1,16 +1,45 @@
 ;;; direnv.el --- Support for direnv -*- lexical-binding: t; -*-
 
+;; Copyright (c) 2017  wouter bolsterlee
+
 ;; Author: wouter bolsterlee <wouter@bolsterl.ee>
 ;; Version: 2.2.0
 ;; Package-Requires: ((emacs "25.1") (dash "2.12.0"))
 ;; Keywords: direnv, environment, processes, unix, tools
 ;; URL: https://github.com/wbolster/emacs-direnv
-;;
+
 ;; This file is not part of GNU Emacs.
-
-;;; License:
-
-;; 3-clause "new bsd"; see readme for details.
+;;
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;; * Redistributions of source code must retain the above copyright
+;;   notice, this list of conditions and the following disclaimer.
+;;
+;; * Redistributions in binary form must reproduce the above copyright
+;;   notice, this list of conditions and the following disclaimer in
+;;   the documentation and/or other materials provided with the
+;;   distribution.
+;;
+;; * Neither the name of the author nor the names of the contributors
+;;   may be used to endorse or promote products derived from this
+;;   software without specific prior written permission.
+;;
+;; This software is provided by the copyright holders and contributors
+;; "as is" and any express or implied warranties, including, but not
+;; limited to, the implied warranties of merchantability and fitness
+;; for a particular purpose are disclaimed. In no event shall the
+;; copyright holder or contributors be liable for any direct,
+;; indirect, incidental, special, exemplary, or consequential damages
+;; (including, but not limited to, procurement of substitute goods or
+;; services; loss of use, data, or profits; or business interruption)
+;; however caused and on any theory of liability, whether in contract,
+;; strict liability, or tort (including negligence or otherwise)
+;; arising in any way out of the use of this software, even if advised
+;; of the possibility of such damage.
 
 ;;; Commentary:
 

--- a/direnv.el
+++ b/direnv.el
@@ -25,7 +25,7 @@
 (require 'subr-x)
 
 (defgroup direnv nil
-  "direnv integration for emacs"
+  "Direnv integration for Emacs."
   :group 'environment
   :prefix "direnv-")
 
@@ -95,7 +95,7 @@ use `default-directory', since there is no file name (or directory)."
   (unless direnv--executable
     (setq direnv--executable (direnv--detect)))
   (unless direnv--executable
-    (user-error "Could not find the direnv executable. Is exec-path correct?"))
+    (user-error "Could not find the direnv executable.  Is `exec-path' correct?"))
   (let ((environment process-environment)
         (stderr-tempfile (make-temp-file "direnv-stderr"))) ;; call-process needs a file for stderr output
     (unwind-protect
@@ -286,7 +286,7 @@ visited (local) file."
   sh-mode "envrc"
   "Major mode for .envrc files as used by direnv.
 
-Since .envrc files are shell scripts, this mode inherits from sh-mode.
+Since .envrc files are shell scripts, this mode inherits from `sh-mode'.
 \\{direnv-envrc-mode-map}")
 
 ;;;###autoload


### PR DESCRIPTION
As mentioned in https://github.com/wbolster/emacs-direnv/issues/73#issuecomment-1002663128, these patches would add a commentary section without direct references to the README.  While I was at it, I also fixed some checkdoc issues and copied the license directly into the source file (as is recommended for BSD-3).  I hope it is ok to propose this all at once, if not just tell me what commit to remove.